### PR TITLE
fixing the get request error output in the weather.py

### DIFF
--- a/etc/skel/.config/polybar/scripts/weather.py
+++ b/etc/skel/.config/polybar/scripts/weather.py
@@ -24,8 +24,8 @@ LANG = "en"
 #LANG = "nl"
 #LANG = "hu"
 
-REQ = requests.get("http://api.openweathermap.org/data/2.5/weather?id={}&lang={}&appid={}&units={}".format(CITY, LANG,  API_KEY, UNITS))
 try:
+    REQ = requests.get("http://api.openweathermap.org/data/2.5/weather?id={}&lang={}&appid={}&units={}".format(CITY, LANG,  API_KEY, UNITS))
     # HTTP CODE = OK
     if REQ.status_code == 200:
         CURRENT = REQ.json()["weather"][0]["description"].capitalize()


### PR DESCRIPTION
Move the request variable -REQ- into the try block so it can be catch in case of an error in the get request. For example if there isn't an internet connection or any other reason that prevent making the request.