### PR TITLE
updated display query for bspwm

### DIFF
--- a/etc/skel/.config/polybar/launch.sh
+++ b/etc/skel/.config/polybar/launch.sh
@@ -56,7 +56,7 @@ case $desktop in
 
     bspwm|/usr/share/xsessions/bspwm)
     if type "xrandr" > /dev/null; then
-      for m in $(xrandr --query | grep " connected" | cut -d" " -f1); do
+      for m in $(bpsc query -M --names); do
         MONITOR=$m polybar --reload mainbar-bspwm -c ~/.config/polybar/config &
       done
     else


### PR DESCRIPTION
I ran the command xrandr --query | grep connected | cut -d" " -f1 on my laptop and it reported and hdmi display was available but there were no external displays connected. I think a more reliable way is to use bspc query for this.

edit: I ran the original command again and it works fine, but better safe than sorry! I would still suggest using bspc query.